### PR TITLE
sync-to-async

### DIFF
--- a/src/main/java/org/apache/pulsar/logstash/outputs/Pulsar.java
+++ b/src/main/java/org/apache/pulsar/logstash/outputs/Pulsar.java
@@ -224,7 +224,7 @@ public class Pulsar implements Output {
                 logger.debug("topic is {}, message is {}", eventTopic, s);
                 getProducer(eventTopic).newMessage()
                         .value(s.getBytes())
-                        .send();
+                        .sendAsync();
             } catch (Exception e) {
                 logger.error("fail to send message", e);
             }


### PR DESCRIPTION
While testing this output plugin my colleague and I found that there was a general limitation to how much it could send. Pulsar itself had no issues dealing with the amount of throughput, but the machine running the Logstash with this plugin did have some limits. 

Our setup for the findings: 

So we were running two EC2 instances both with 16 cores, 30 gb, 100 gb storage (c4.4xlarge).

One ran one Logstash instance with the consumer aka the input plugin equivalent https://github.com/streamnative/logstash-input-pulsar. The other ran this logstash-output-pulsar plugin.

With the change in this PR and the change in this PR #24 we were able to get these results: 

Output pulsar with sync 16 core 1 publisher 8 threads => 2.5k ~
Output pulsar with async 16 core 1 publisher 8 threads => 26k ~
Output pulsar with async 16 core 1 publisher 8 threads with batching => 40k ~
Output pulsar with async 16 core 2 publisher 8 threads with batching => 70k ~
Output pulsar with async 16 core 1 publisher 16 (default) threads with batching => 40/41k ~
Output pulsar with async 16 core 3 publisher 8 threads with batching => 75k ~ (354 Mbit/s ~ )
